### PR TITLE
Issue#23 javax imports in rest bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,6 @@ jobs:
     - name: Gradle version
       run: ./gradlew --no-daemon --version
     - name: Build with Gradle
-      run: ./gradlew build --info
+      run: ./gradlew clean build --info
     - name: Run Performance Tests
       run: ./gradlew perfTest --info

--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -148,7 +148,7 @@ org.mongodb:bson:5.6.3
 org.apache.commons:commons-lang3:3.12.0
 
 org.eclipse.fennec.bnd:org.eclipse.fennec.bnd.library:0.0.8
-org.eclipse.fennec.bnd:org.eclipse.fennec.jacoco.bnd.library:0.0.8
-org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.bnd.library:0.0.8
+org.eclipse.fennec.bnd:org.eclipse.fennec.jacoco.bnd.library:0.0.9
+org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.bnd.library:0.0.9
 org.eclipse.fennec.emf:org.eclipse.fennec.emf.osgi.bnd.library.workspace:0.0.1-SNAPSHOT
 org.eclipse.fennec.models:org.eclipse.fennec.common.models.library:0.0.1-SNAPSHOT

--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -8,6 +8,8 @@ jakarta.annotation:jakarta.annotation-api:2.1.1
 jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
 jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
 jakarta.xml.bind:jakarta.xml.bind-api:4.0.0
+jakarta.inject:jakarta.inject-api:2.0.1
+
 javax.json:javax.json-api:1.1.4
 
 commons-beanutils:commons-beanutils:1.9.4

--- a/cnf/ext/libraries.maven
+++ b/cnf/ext/libraries.maven
@@ -1,14 +1,3 @@
-org.geckoprojects.bnd:org.gecko.bnd.dimc.library:0.0.9
-org.geckoprojects.bnd:org.gecko.bnd.jacoco.library:0.0.9
-org.geckoprojects.bnd:org.gecko.bnd.osgitest.library:0.0.9
-
-org.geckoprojects.emf:org.gecko.emf.osgi.bnd.library.workspace:6.3.0
-
-org.geckoprojects.emf.utils:org.gecko.emf.util.jakartars.bnd.library.workspace:2.3.0
-
-org.geckoprojects.search:org.gecko.search.bnd.library:1.4.0
-
-org.geckoprojects.emf.persistence:org.gecko.emf.repository.bnd.library.workspace:6.2.0-SNAPSHOT
 
 
 

--- a/cnf/ext/libraries.maven
+++ b/cnf/ext/libraries.maven
@@ -1,6 +1,6 @@
-org.geckoprojects.bnd:org.gecko.bnd.dimc.library:2.1.0-SNAPSHOT
-org.geckoprojects.bnd:org.gecko.bnd.jacoco.library:2.1.0-SNAPSHOT
-org.geckoprojects.bnd:org.gecko.bnd.osgitest.library:2.1.0-SNAPSHOT
+org.geckoprojects.bnd:org.gecko.bnd.dimc.library:0.0.9
+org.geckoprojects.bnd:org.gecko.bnd.jacoco.library:0.0.9
+org.geckoprojects.bnd:org.gecko.bnd.osgitest.library:0.0.9
 
 org.geckoprojects.emf:org.gecko.emf.osgi.bnd.library.workspace:6.3.0
 
@@ -9,5 +9,6 @@ org.geckoprojects.emf.utils:org.gecko.emf.util.jakartars.bnd.library.workspace:2
 org.geckoprojects.search:org.gecko.search.bnd.library:1.4.0
 
 org.geckoprojects.emf.persistence:org.gecko.emf.repository.bnd.library.workspace:6.2.0-SNAPSHOT
+
 
 

--- a/org.eclipse.fennec.codec.rest/bnd.bnd
+++ b/org.eclipse.fennec.codec.rest/bnd.bnd
@@ -4,7 +4,11 @@
 	org.eclipse.fennec.codec.api;version=snapshot,\
 	osgi.cmpn,\
 	org.eclipse.fennec.codec,\
-	jakarta.ws.rs-api,\
+	jakarta.ws.rs-api;version=latest,\
+	jakarta.inject.jakarta.inject-api;version=latest,\
 	org.eclipse.fennec.model.metadata,\
 	org.eclipse.fennec.emf.osgi.model.info,\
 	org.osgi.service.jakartars
+	
+#So inherited @Reference are put in the service description xml
+-dsannotations-options: inherit

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/AbstractJakartaCodecAnnotationHandler.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/AbstractJakartaCodecAnnotationHandler.java
@@ -16,10 +16,6 @@ package org.eclipse.fennec.codec.rest.jakartas;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Variant;
-
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -27,6 +23,10 @@ import org.eclipse.emf.ecore.util.Diagnostician;
 import org.eclipse.fennec.codec.rest.annotations.ContentNotEmpty;
 import org.eclipse.fennec.codec.rest.annotations.ResourceEClass;
 import org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Variant;
 
 /**
  * Base class to handle Codec resource annotation and turn them into Codec load or save options

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/JakartaRestConstants.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/JakartaRestConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2012 - 2026 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ */
+package org.eclipse.fennec.codec.rest.jakartas;
+
+/**
+ * 
+ * @author ilenia
+ * @since May 19, 2026
+ */
+public interface JakartaRestConstants {
+	
+	String RESOLVED_RESOURCE_SET_FACTORY = "resolved.resource.set.factory";
+
+}

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/filter/BasicResourceSetFilter.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/filter/BasicResourceSetFilter.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2012 - 2026 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ */
+package org.eclipse.fennec.codec.rest.jakartas.filter;
+
+import java.io.IOException;
+
+import org.eclipse.fennec.codec.rest.jakartas.JakartaRestConstants;
+import org.eclipse.fennec.emf.osgi.ResourceSetFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsExtension;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+
+/**
+ * 
+ * @author ilenia
+ * @since May 19, 2026
+ */
+
+@Component
+@JakartarsExtension
+@JakartarsName("ResourceSetFilter")
+@ServiceRanking(1) 
+public class BasicResourceSetFilter implements ContainerRequestFilter {
+
+	@Reference
+	private ResourceSetFactory resourceSetFactory;
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see jakarta.ws.rs.container.ContainerRequestFilter#filter(jakarta.ws.rs.container.ContainerRequestContext)
+	 */
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		requestContext.setProperty(JakartaRestConstants.RESOLVED_RESOURCE_SET_FACTORY, resourceSetFactory);
+	}
+	
+
+}

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/BaseJakartaCodecMessageBodyReaderWriter.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/BaseJakartaCodecMessageBodyReaderWriter.java
@@ -22,13 +22,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
-
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -43,6 +36,14 @@ import org.eclipse.fennec.codec.rest.jakartas.AbstractJakartaCodecAnnotationHand
 import org.eclipse.fennec.emf.osgi.ResourceSetFactory;
 import org.eclipse.fennec.emf.osgi.model.info.EMFModelInfo;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
 
 /**
  * 
@@ -52,7 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 public abstract class BaseJakartaCodecMessageBodyReaderWriter<R, W> extends AbstractJakartaCodecAnnotationHandler
 implements MessageBodyReader<R>, MessageBodyWriter<W> {
 
-@Reference
+@Reference(cardinality = ReferenceCardinality.MANDATORY)
 EMFModelInfo modelInfo;
 
 /**

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/EMFResourceMessageBodyHandler.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/EMFResourceMessageBodyHandler.java
@@ -19,18 +19,10 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
-import javax.ws.rs.ext.Provider;
-
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fennec.codec.rest.annotations.AnnotationConverter;
+import org.eclipse.fennec.codec.rest.jakartas.JakartaRestConstants;
 import org.eclipse.fennec.emf.osgi.ResourceSetFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -41,6 +33,17 @@ import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsExtension;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * {@link MessageBodyReader} and {@link MessageBodyWriter} that handle {@link Resource}.
@@ -63,8 +66,8 @@ import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
 @Consumes(MediaType.WILDCARD)
 public class EMFResourceMessageBodyHandler<R extends Resource, W extends Resource> extends BaseJakartaCodecMessageBodyReaderWriter<R, W>{
 
-	@Reference
-	private ResourceSetFactory resourceSetFactory;
+	@Context
+    private jakarta.inject.Provider<ContainerRequestContext> requestContextProvider;
 	
 	/*
 	 * (non-Javadoc)
@@ -127,7 +130,7 @@ public class EMFResourceMessageBodyHandler<R extends Resource, W extends Resourc
 	}
 	
 	public ResourceSetFactory getResourceSetFactory() {
-		return resourceSetFactory;
+		return (ResourceSetFactory) requestContextProvider.get().getProperty(JakartaRestConstants.RESOLVED_RESOURCE_SET_FACTORY);
 	}
 	
 	@Reference(unbind = "removeAnnotationConverter", cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/EObjectMessageBodyHandler.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/internal/EObjectMessageBodyHandler.java
@@ -19,21 +19,13 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
-import javax.ws.rs.ext.Provider;
-
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.rest.annotations.AnnotationConverter;
+import org.eclipse.fennec.codec.rest.jakartas.JakartaRestConstants;
 import org.eclipse.fennec.emf.osgi.ResourceSetFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,6 +36,17 @@ import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsExtension;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * {@link MessageBodyReader} and {@link MessageBodyWriter} that handle {@link EObject}.
@@ -56,7 +59,7 @@ import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
 @Component(
 		service = {MessageBodyReader.class, MessageBodyWriter.class},
 		enabled = true,
-		scope = ServiceScope.SINGLETON
+		scope = ServiceScope.PROTOTYPE
 	)
 @JakartarsExtension
 @JakartarsName("EMFEObjectMessagebodyReaderWriter")
@@ -66,8 +69,8 @@ import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
 @Consumes(MediaType.WILDCARD)
 public class EObjectMessageBodyHandler<R extends EObject, W extends EObject> extends BaseJakartaCodecMessageBodyReaderWriter<R, W>{
 
-	@Reference
-	private ResourceSetFactory resourceSetFactory;
+	@Context
+    private jakarta.inject.Provider<ContainerRequestContext> requestContextProvider;
 	
 	/*
 	 * (non-Javadoc)
@@ -167,6 +170,6 @@ public class EObjectMessageBodyHandler<R extends EObject, W extends EObject> ext
 
 	@Override
 	protected ResourceSetFactory getResourceSetFactory() {
-		return resourceSetFactory;
+		return (ResourceSetFactory) requestContextProvider.get().getProperty(JakartaRestConstants.RESOLVED_RESOURCE_SET_FACTORY);
 	}
 }


### PR DESCRIPTION
Adjusted old javax imports and replaced them with jakarta imports
Added default resource set filter 
Added option -dsannotations-options: inherit in codec.rest bnd to allow inherited references to be put in manifest