### PR TITLE
solves #25 - Missing checks for new RootElement annotation in codec.rest

### DIFF
--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -147,8 +147,8 @@ org.slf4j:slf4j-api:1.7.36
 org.mongodb:bson:5.6.3
 org.apache.commons:commons-lang3:3.12.0
 
-org.eclipse.fennec.bnd:org.eclipse.fennec.bnd.library:0.0.8
+org.eclipse.fennec.bnd:org.eclipse.fennec.bnd.library:0.0.9
 org.eclipse.fennec.bnd:org.eclipse.fennec.jacoco.bnd.library:0.0.9
 org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.bnd.library:0.0.9
-org.eclipse.fennec.emf:org.eclipse.fennec.emf.osgi.bnd.library.workspace:0.0.1-SNAPSHOT
+org.eclipse.fennec.emf:org.eclipse.fennec.emf.osgi.bnd.library.workspace:0.1.2
 org.eclipse.fennec.models:org.eclipse.fennec.common.models.library:0.0.1-SNAPSHOT

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/common/AbstractCodecAnnotationHandler.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/common/AbstractCodecAnnotationHandler.java
@@ -30,6 +30,7 @@ import org.eclipse.fennec.codec.rest.annotations.EMFResourceOptions;
 import org.eclipse.fennec.codec.rest.annotations.ResourceEClass;
 import org.eclipse.fennec.codec.rest.annotations.ResourceOption;
 import org.eclipse.fennec.codec.rest.annotations.ValidateContent;
+import org.eclipse.fennec.codec.rest.annotations.json.RootElement;
 
 /**
  * 
@@ -99,6 +100,10 @@ public abstract class AbstractCodecAnnotationHandler {
 			if (annotation instanceof ValidateContent) {
 				handleValidateContent(resource);
 			}
+			if (annotation instanceof RootElement) {
+				handleResourceRootType(resource, annotation);
+				handleResourceRootSchema(resource, annotation);
+			}
 		}
 
 	}
@@ -125,6 +130,23 @@ public abstract class AbstractCodecAnnotationHandler {
 	 * @param annotation the content not empty annotation
 	 */
 	abstract protected void handleContentNotEmpty(Resource resource, ContentNotEmpty annotation);
+	
+	/**
+	 * Handles the {@link RootElement} - rootType annotation
+	 * 
+	 * @param resource   the EMF resource
+	 * @param annotation the annotation
+	 */
+	abstract protected void handleResourceRootType(Resource resource, Annotation annotation);
+	
+	/**
+	 * Handles the {@link RootElement} - rootSchema annotation
+	 * 
+	 * @param resource   the EMF resource
+	 * @param annotation the annotation
+	 */
+	abstract protected void handleResourceRootSchema(Resource resource, Annotation annotation);
+	
 
 	/**
 	 * Writes the diagnostic content to a String

--- a/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/AbstractJakartaCodecAnnotationHandler.java
+++ b/org.eclipse.fennec.codec.rest/src/org/eclipse/fennec/codec/rest/jakartas/AbstractJakartaCodecAnnotationHandler.java
@@ -20,8 +20,10 @@ import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fennec.codec.rest.annotations.ContentNotEmpty;
 import org.eclipse.fennec.codec.rest.annotations.ResourceEClass;
+import org.eclipse.fennec.codec.rest.annotations.json.RootElement;
 import org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -35,9 +37,10 @@ import jakarta.ws.rs.core.Variant;
  */
 public class AbstractJakartaCodecAnnotationHandler extends AbstractCodecAnnotationHandler {
 
+	
 	/* 
 	 * (non-Javadoc)
-	 * @see org.gecko.emf.rest.common.AbstractEMFAnnotationHandler#handleValidateContent(org.eclipse.emf.ecore.resource.Resource)
+	 * @see org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler#handleValidateContent(org.eclipse.emf.ecore.resource.Resource)
 	 */
 	@Override
 	protected void handleValidateContent(Resource resource) {
@@ -53,9 +56,10 @@ public class AbstractJakartaCodecAnnotationHandler extends AbstractCodecAnnotati
 		}
 	}
 
+	
 	/* 
 	 * (non-Javadoc)
-	 * @see org.gecko.emf.rest.common.AbstractEMFAnnotationHandler#handleResourceEClass(org.eclipse.emf.ecore.resource.Resource, java.lang.annotation.Annotation)
+	 * @see org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler#handleResourceEClass(org.eclipse.emf.ecore.resource.Resource, java.lang.annotation.Annotation)
 	 */
 	@Override
 	protected void handleResourceEClass(Resource resource, Annotation annotation) {
@@ -72,9 +76,11 @@ public class AbstractJakartaCodecAnnotationHandler extends AbstractCodecAnnotati
 		}
 	}
 
+
+	
 	/* 
 	 * (non-Javadoc)
-	 * @see org.gecko.emf.rest.common.AbstractEMFAnnotationHandler#handleContentNotEmpty(org.eclipse.emf.ecore.resource.Resource, org.gecko.emf.rest.annotations.ContentNotEmpty)
+	 * @see org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler#handleContentNotEmpty(org.eclipse.emf.ecore.resource.Resource, org.eclipse.fennec.codec.rest.annotations.ContentNotEmpty)
 	 */
 	@Override
 	protected void handleContentNotEmpty(Resource resource, ContentNotEmpty annotation) {
@@ -85,6 +91,49 @@ public class AbstractJakartaCodecAnnotationHandler extends AbstractCodecAnnotati
 			List<Variant> encoded = Variant.encodings(annotation.message()).build();
 			Response res = Response.notAcceptable(encoded).build();
 			throw new WebApplicationException(res);
+		}
+	}
+
+
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler#handleResourceRootType(org.eclipse.emf.ecore.resource.Resource, java.lang.annotation.Annotation)
+	 */
+	@Override
+	protected void handleResourceRootType(Resource resource, Annotation annotation) {
+		if (resource == null || annotation == null) {
+			return;
+		}
+		String rootType = ((RootElement) annotation).rootType();
+		if(rootType.isBlank()) return;
+		for (EObject eObject : resource.getContents()) {
+			if (!rootType.equals(EcoreUtil.getURI(eObject.eClass()).toString())) {
+				List<Variant> encoded = Variant.encodings(rootType).build();
+				Response res = Response.notAcceptable(encoded).build();
+				throw new WebApplicationException(res);
+			}
+		}
+	}
+
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.eclipse.fennec.codec.rest.common.AbstractCodecAnnotationHandler#handleResourceRootSchema(org.eclipse.emf.ecore.resource.Resource, java.lang.annotation.Annotation)
+	 */
+	@Override
+	protected void handleResourceRootSchema(Resource resource, Annotation annotation) {
+		if (resource == null || annotation == null) {
+			return;
+		}
+		String rootSchema = ((RootElement) annotation).rootSchema();
+		if(rootSchema.isBlank()) return;
+		for (EObject eObject : resource.getContents()) {
+			if (!rootSchema.equals(eObject.eClass().getEPackage().getNsURI())) {
+				List<Variant> encoded = Variant.encodings(rootSchema).build();
+				Response res = Response.notAcceptable(encoded).build();
+				throw new WebApplicationException(res);
+			}
 		}
 	}
 


### PR DESCRIPTION
In the AbstractJakartaCodecAnnotationHandler we miss a method to handle the RootElement annotations, and in the checkResourceByAnnotation we have to add these checks.