### PR TITLE
Sods v1.10.0

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -58,15 +58,6 @@ javac.target: 17
  	aQute.bnd.repository.p2.provider.P2Repository; \
  	url = https://download.eclipse.org/modeling/emf/compare/updates/releases/latest/; \
  	name = EMFCompare
- 	
--plugin.5.JitPack: \
-    aQute.bnd.repository.maven.provider.MavenBndRepository; \
-        snapshotUrl="https://jitpack.io/"; \
-        releaseUrl=https://jitpack.io; \
-        index=${.}/ext/jitpack.mvn; \
-        readOnly=true; \
-        poll.time=-1; \
-        name="JitPack"
 
 -fixupmessages: \
 	"No translation";is:=ignore,\

--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -149,7 +149,7 @@ org.eclipse.fennec.models:org.eclipse.fennec.common.models.library:0.0.1-SNAPSHO
 de.siegmar:fastcsv:4.2.0
 
 #Deps needed for ods exporter
-#com.github.miachm.sods:SODS:1.9.0
+com.github.miachm.sods:SODS:1.10.0
 
 #Deps needed for xslx exporter
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.poi:5.3.0_1

--- a/cnf/ext/jitpack.mvn
+++ b/cnf/ext/jitpack.mvn
@@ -1,2 +1,0 @@
-#Deps needed for ods exporter: We use the sha of our PR till a new minor release with our change included is in maven central 
-com.github.miachm:SODS:68689f7

--- a/org.eclipse.fennec.codec.ods/bnd.bnd
+++ b/org.eclipse.fennec.codec.ods/bnd.bnd
@@ -19,5 +19,4 @@ Bundle-Description: ODS format provider for the Fennec EMF Codec
 -testpath: \
 	org.eclipse.fennec.codec.tests;version=snapshot
 	
-Export-Package: com.github.miachm.sods;version="1.9.0"
 -privatepackage: org.eclipse.fennec.codec.ods

--- a/org.eclipse.fennec.codec.playground/launch.bndrun
+++ b/org.eclipse.fennec.codec.playground/launch.bndrun
@@ -80,7 +80,9 @@
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	slf4j.api;version='[1.7.36,1.7.37)',\
 	slf4j.simple;version='[1.7.36,1.7.37)',\
-	org.eclipse.fennec.codec.rest;version=snapshot
+	org.eclipse.fennec.codec.rest;version=snapshot,\
+	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
+	com.github.miachm.sods;version='[1.10.0,1.10.1)'
 
 -runrequires: \
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)',\

--- a/org.eclipse.fennec.codec.workspace.library/required.bndrun
+++ b/org.eclipse.fennec.codec.workspace.library/required.bndrun
@@ -63,4 +63,5 @@
 	org.eclipse.fennec.codec.rlang;version=snapshot,\
 	org.eclipse.fennec.codec.tabular;version=snapshot,\
 	org.eclipse.fennec.codec.tabular.model;version=snapshot,\
-	org.eclipse.fennec.codec.xlsx;version=snapshot
+	org.eclipse.fennec.codec.xlsx;version=snapshot,\
+	com.github.miachm.sods;version='[1.10.0,1.10.1)'


### PR DESCRIPTION
Updated sods dependency to official maven release, v 1.10.0
Removed repackaged of sods in ods bundle (not needed anymore, I think)
