### PR TITLE
solves issue#12: codec value registry as osgi service

### DIFF
--- a/docs/codec-v2-development-guide.md
+++ b/docs/codec-v2-development-guide.md
@@ -77,6 +77,37 @@ The `@Capability` for jsonschema goes on `v2/package-info.java` because `JsonSch
 
 ---
 
+**Fix: `CODEC_FEATURE_VALUE_WRITERS` name-based binding silently ignored; tabular path now supports custom value writers:**
+
+Two related issues fixed, both in the `CODEC_FEATURE_VALUE_WRITERS` / `CODEC_FEATURE_VALUE_READERS` option paths.
+
+*Issue 1 — Name-based binding ignored in Jackson path (JSON/YAML/BSON/CBOR):*
+`ContextHelper.getFeatureValueWriter()` and `getFeatureValueReader()` existed but were never called inside `resolveEffectiveWriter()` / `resolveEffectiveReader()`. Passing `CODEC_FEATURE_VALUE_WRITERS = Map.of(attr, "myWriterName")` silently fell through to the default serializer.
+
+Fix: added Priority 2 (name lookup from `CodecValueRegistry`) in both `AttributeSerializationEntry` and `AttributeDeserializationEntry`, between Priority 1 (instance binding via `CODEC_FEATURE_VALUE_WRITER_INSTANCES`) and Priority 3 (annotation-resolved writer name).
+
+*Issue 2 — Custom value writers silently ignored in tabular path (CSV/ODS/XLSX/R-Lang):*
+`TabularDocumentBuilder` builds typed `Cell` objects directly from `EObject.eGet()` values without going through `AttributeSerializationEntry`, so `CODEC_FEATURE_VALUE_WRITERS` had no effect.
+
+Fix:
+- Added `CodecOptions.INTERNAL_VALUE_REGISTRY` (in `codec.api`) to carry the `CodecValueRegistry` through `effectiveOptions` from `CodecResource` to `TabularDocumentBuilder`, avoiding a circular dependency (tabular depends on codec; codec must not depend on tabular).
+- Threaded `registry` + `featureWriters` map through the entire tabular build chain (`buildIgnore`, `buildFlat`, `buildSqlTables`, `makeAttributeCell`).
+- Added `invokeWriterAsCell()` + `MinimalWriterContext` — invokes the writer through a temporary `JsonMapper` generator, captures the output as bytes, reads it back via a `JsonParser`, and maps the token type to the appropriate `Cell` subtype (String/Long/Double/Boolean).
+
+*TCK coverage extended:*
+Added `writerResolvedByNameFromRegistry()` and `readerResolvedByNameFromRegistry()` to `AbstractCustomValueTCK`. YAML, CBOR, and BSON automatically inherit both tests.
+
+*Files changed:*
+- `org.eclipse.fennec.codec.api/src/.../constants/CodecOptions.java` — `INTERNAL_VALUE_REGISTRY`
+- `org.eclipse.fennec.codec/src/.../ser/AttributeSerializationEntry.java` — Priority 2 in `resolveEffectiveWriter()`
+- `org.eclipse.fennec.codec/src/.../deser/AttributeDeserializationEntry.java` — Priority 2 in `resolveEffectiveReader()`
+- `org.eclipse.fennec.codec/src/.../resource/CodecResource.java` — inject registry into `effectiveOptions`
+- `org.eclipse.fennec.codec.tabular/src/.../TabularDocumentBuilder.java` — `invokeWriterAsCell()`, `MinimalWriterContext`, registry/featureWriters threading
+- `org.eclipse.fennec.codec.tests/src/.../tck/AbstractCustomValueTCK.java` — 2 new name-binding TCK tests + `createResource(CodecValueRegistry)` helper
+- `org.eclipse.fennec.codec/test/.../CodecResourceCustomValueTest.java` — `NameBindingTests` nested class (2 tests)
+
+---
+
 **Session Summary (2026-06-25 latest):**
 
 **`idOnTop` bug fix + EIDAttribute feature promotion (JSON/YAML path):**
@@ -216,8 +247,8 @@ path silently skipped them — so the same object exported as CSV-IGNORE vs ODS-
   the IGNORE special case is gone. `CsvFormatDelegate` deleted (unreferenced).
 - Behavior change: ODS/XLSX/R IGNORE are now option-aware (null/default/empty columns drop unless the
   matching `serialize*` option is set) — the intended consistency fix.
-- Out of scope (follow-ups): id/type strategy (`_id`/`_type` columns) for the tabular grid; custom
-  value writers (`CodecValueWriter`) on the tabular path — CSV IGNORE no longer supports them.
+- Out of scope (follow-up): id/type strategy (`_id`/`_type` columns) for the tabular grid.
+- ~~Custom value writers (`CodecValueWriter`) on the tabular path~~ — **Fixed 2026-06-26**: `CODEC_FEATURE_VALUE_WRITERS` is now supported in `TabularDocumentBuilder` via `invokeWriterAsCell` + `MinimalWriterContext`; see §7.3.
 - Tests: `CsvEnumSerializationTest` (CSV enum strategies), `TabularDocumentBuilderOptionTest`
   (format-agnostic value gate + enums); updated `TabularDocumentBuilderCellTypingTest`'s null-cell
   test to keep the column via `serializeNull(true)`. Full `./gradlew build` green.
@@ -1220,6 +1251,16 @@ for (Diagnostic diag : diagnostics.getDiagnostics()) {
 - Affected all properties read in `CodecResource.createObjectMapper()`: `FIELD_ORDER`, `SMART_COMPRESSION`, `DATE_FORMAT`, `IGNORE_FEATURES`, `USE_NAMES_FROM_EXTENDED_METADATA`, all `EXPAND_*`
 - Fix: replaced manual `containsKey(key)` loop with `ConfigMergeHelper.getValue()`, which already tries both key forms and is used by every `mergeWith()` path
 - Tests: `ConfigurationResolverTest.GetGlobalProperty` (5 tests)
+
+✅ **`CODEC_FEATURE_VALUE_WRITERS` name-based binding silently ignored** (`AttributeSerializationEntry`, `AttributeDeserializationEntry`)
+- `ContextHelper.getFeatureValueWriter/Reader()` existed but was never called in `resolveEffectiveWriter/Reader()` — passing a writer/reader name via `CODEC_FEATURE_VALUE_WRITERS`/`READERS` options silently fell through to the default serializer in all Jackson-based formats (JSON, YAML, BSON, CBOR)
+- Fix: added Priority 2 (name-based lookup from registry) in both entry classes, between Priority 1 (instance binding via `CODEC_FEATURE_VALUE_WRITER_INSTANCES`) and Priority 3 (annotation-resolved writer name)
+- Tests: `CodecResourceCustomValueTest.NameBindingTests` (2 tests); `AbstractCustomValueTCK` extended with `writerResolvedByNameFromRegistry` + `readerResolvedByNameFromRegistry` (automatically run by YAML, CBOR, BSON TCK subclasses)
+
+✅ **`CODEC_FEATURE_VALUE_WRITERS` silently ignored on the tabular path (CSV/ODS/XLSX/R-Lang)** (`TabularDocumentBuilder`)
+- `TabularDocumentBuilder` builds `Cell` objects directly from `EObject.eGet()` values, bypassing `AttributeSerializationEntry` entirely — `CODEC_FEATURE_VALUE_WRITERS` had no effect regardless of what was configured
+- Fix: added `CodecOptions.INTERNAL_VALUE_REGISTRY` (in `codec.api`) to carry the `CodecValueRegistry` through `effectiveOptions` from `CodecResource` without a circular dependency; threaded `registry` + `featureWriters` map through the entire tabular build chain; added `invokeWriterAsCell()` + `MinimalWriterContext` to invoke the writer via a temporary Jackson generator and map the resulting token to the appropriate `Cell` subtype (String/Long/Double/Boolean)
+- Verified with Gogo command `exportWithWriter CSV FLAT` in playground bundle
 
 **2026-06-25:**
 ✅ **`idOnTop=true` had no effect on JSON/YAML field order** (`CodecEObjectSerializer`)

--- a/org.eclipse.fennec.codec.api/src/org/eclipse/fennec/codec/constants/CodecOptions.java
+++ b/org.eclipse.fennec.codec.api/src/org/eclipse/fennec/codec/constants/CodecOptions.java
@@ -579,4 +579,11 @@ public final class CodecOptions {
      */
     public static final String CODEC_THROW_ON_VALIDATION_WARNINGS =
             "codec.throwOnValidationWarnings";
+
+    /**
+     * Internal: {@code CodecValueRegistry} instance forwarded from {@code CodecResource} to
+     * format delegates (e.g. tabular) so that named value writers can be resolved at
+     * serialization time. Not a user-facing option — set automatically by the infrastructure.
+     */
+    public static final String INTERNAL_VALUE_REGISTRY = "codec.internal.valueRegistry";
 }

--- a/org.eclipse.fennec.codec.bson/src/org/eclipse/fennec/codec/bson/BsonResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.bson/src/org/eclipse/fennec/codec/bson/BsonResourceFactoryComponent.java
@@ -17,11 +17,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for the
@@ -40,18 +43,33 @@ public class BsonResourceFactoryComponent extends ResourceFactoryImpl {
 
     private final MetadataService metadataService;
     private final BsonFormatProvider formatProvider = new BsonFormatProvider();
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public BsonResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
     }
 
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
+    }
+
     @Override
     public Resource createResource(URI uri) {
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 formatProvider);
     }
 }

--- a/org.eclipse.fennec.codec.cbor/src/org/eclipse/fennec/codec/cbor/CborResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.cbor/src/org/eclipse/fennec/codec/cbor/CborResourceFactoryComponent.java
@@ -21,11 +21,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * 
@@ -44,6 +47,7 @@ public class CborResourceFactoryComponent extends ResourceFactoryImpl {
 
 	private final MetadataService metadataService;
 	private final CborFormatProvider formatProvider = new CborFormatProvider();
+	private volatile CodecValueRegistry valueRegistry;
 
 	@Activate
 	public CborResourceFactoryComponent(
@@ -51,12 +55,26 @@ public class CborResourceFactoryComponent extends ResourceFactoryImpl {
 		this.metadataService = metadataService;
 	}
 
+	@Reference(
+			cardinality = ReferenceCardinality.OPTIONAL,
+			policy = ReferencePolicy.DYNAMIC,
+			unbind = "unsetValueRegistry"
+	)
+	void setValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = registry;
+	}
+
+	void unsetValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = null;
+	}
+
 	@Override
 	public Resource createResource(URI uri) {
+		CodecValueRegistry reg = valueRegistry;
 		return new CodecResource(
 				uri, metadataService,
 				ConfigurationResolver.defaults(),
-				null, null,
+				reg != null ? reg.copy() : null, null,
 				formatProvider
 				);
 	}

--- a/org.eclipse.fennec.codec.csv/src/org/eclipse/fennec/codec/csv/CsvResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.csv/src/org/eclipse/fennec/codec/csv/CsvResourceFactoryComponent.java
@@ -20,12 +20,15 @@ import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
 import org.eclipse.fennec.codec.tabular.CodecTabularOptions;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.codec.tabular.model.tabular.ReferenceMode;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for CSV-style
@@ -65,10 +68,24 @@ public class CsvResourceFactoryComponent extends ResourceFactoryImpl {
     private static final String SQL_TABLES_EXTENSION = "csvz";
 
     private final MetadataService metadataService;
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public CsvResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
+    }
+
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
     }
 
     @Override
@@ -78,10 +95,11 @@ public class CsvResourceFactoryComponent extends ResourceFactoryImpl {
                         Map.of(CodecTabularOptions.OPTION_REFERENCE_MODE,
                                 ReferenceMode.SQL_TABLES))
                 : new CsvFormatProvider();
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 provider);
     }
 

--- a/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/JsonSchemaResourceFactoryImpl.java
+++ b/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/JsonSchemaResourceFactoryImpl.java
@@ -19,12 +19,15 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.util.MetadataServiceFactory;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.eclipse.fennec.model.metadata.api.MetadataWhiteboard;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * Resource factory for JSON Schema resources.
@@ -50,7 +53,8 @@ import org.osgi.service.component.annotations.Reference;
 public class JsonSchemaResourceFactoryImpl extends ResourceFactoryImpl {
 	
 	private final MetadataService metadataService;
-	
+	private volatile CodecValueRegistry valueRegistry;
+
 	/**
 	 * OSGi DS constructor with injected MetadataService.
 	 *
@@ -60,7 +64,7 @@ public class JsonSchemaResourceFactoryImpl extends ResourceFactoryImpl {
 	public JsonSchemaResourceFactoryImpl(@Reference MetadataService metadataService) {
 		this.metadataService = metadataService;
 	}
-	
+
 	/**
 	 * Non-OSGi constructor for standalone usage.
 	 */
@@ -68,8 +72,19 @@ public class JsonSchemaResourceFactoryImpl extends ResourceFactoryImpl {
 		MetadataWhiteboard whiteboard = MetadataServiceFactory.create();
 		this.metadataService = whiteboard;
 	}
-	
-	
+
+	@Reference(
+			cardinality = ReferenceCardinality.OPTIONAL,
+			policy = ReferencePolicy.DYNAMIC,
+			unbind = "unsetValueRegistry"
+	)
+	void setValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = registry;
+	}
+
+	void unsetValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = null;
+	}
 
 	/**
 	 * Creates a JSON Schema resource for the given URI.
@@ -79,7 +94,7 @@ public class JsonSchemaResourceFactoryImpl extends ResourceFactoryImpl {
 	 */
 	@Override
 	public Resource createResource(URI uri) {
-		return new JsonSchemaResourceImpl(uri, metadataService);
+		return new JsonSchemaResourceImpl(uri, metadataService, valueRegistry);
 	}
 	
 	/**

--- a/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/JsonSchemaResourceImpl.java
+++ b/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/JsonSchemaResourceImpl.java
@@ -84,28 +84,28 @@ public class JsonSchemaResourceImpl extends CodecResource {
 	 * @param uri the resource URI
 	 */
 	public JsonSchemaResourceImpl(URI uri, MetadataService metadataService) {
-		super(uri, metadataService, createResolver(), createValueRegistry(), null);
+		this(uri, metadataService, null);
+	}
+
+	public JsonSchemaResourceImpl(URI uri, MetadataService metadataService, CodecValueRegistry registry) {
+		super(uri, metadataService, createResolver(),
+				registry != null ? registry : createFallbackValueRegistry(), null);
 		this.ePackageToSchemaConverter = new EPackageToJsonSchemaConverter();
 		this.schemaToEPackageConverter = new JsonSchemaToEPackageConverter();
-		
 	}
-	
+
 	private static ConfigurationResolver createResolver() {
 		return ConfigurationResolver.builder()
-				.typeInclude(false)  // jsonschema doesn't use _type for root				
+				.typeInclude(false)  // jsonschema doesn't use _type for root
 				.build();
 	}
 
-	private static CodecValueRegistry createValueRegistry() {
+	private static CodecValueRegistry createFallbackValueRegistry() {
 		CodecValueRegistry registry = new CodecValueRegistry();
-
-		// Register readers and writers for EPackage <-> JsonSchema and EClass <-> JsonSchema 
 		registry.register(new EPackageValueReader());
 		registry.register(new EPackageValueWriter());
-		
 		registry.register(new EClassValueReader());
 		registry.register(new EClassValueWriter());
-
 		return registry;
 	}
 

--- a/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/value/EPackageValueReader.java
+++ b/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/value/EPackageValueReader.java
@@ -19,7 +19,9 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.fennec.codec.jsonschema.v2.converter.JsonSchemaToEPackageConverter;
 import org.eclipse.fennec.codec.value.CodecReaderContext;
+import org.eclipse.fennec.codec.value.CodecValueReader;
 import org.eclipse.fennec.codec.value.ReferenceValueReader;
+import org.osgi.service.component.annotations.Component;
 
 import tools.jackson.core.TreeNode;
 import tools.jackson.databind.JsonNode;
@@ -61,6 +63,7 @@ import tools.jackson.databind.JsonNode;
  * @since 2025
  * @see EPackageValueWriter
  */
+@Component(service = CodecValueReader.class)
 public class EPackageValueReader implements ReferenceValueReader<EPackage> {
 
 	private final JsonSchemaToEPackageConverter converter;

--- a/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/value/EPackageValueWriter.java
+++ b/org.eclipse.fennec.codec.jsonschema/src/org/eclipse/fennec/codec/jsonschema/v2/value/EPackageValueWriter.java
@@ -22,8 +22,10 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.fennec.codec.jsonschema.v2.converter.EPackageToJsonSchemaConverter;
+import org.eclipse.fennec.codec.value.CodecValueWriter;
 import org.eclipse.fennec.codec.value.CodecWriterContext;
 import org.eclipse.fennec.codec.value.ReferenceValueWriter;
+import org.osgi.service.component.annotations.Component;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -65,6 +67,7 @@ import tools.jackson.databind.json.JsonMapper;
  * @since 2025
  * @see EPackageValueReader
  */
+@Component(service = CodecValueWriter.class)
 public class EPackageValueWriter implements ReferenceValueWriter<EPackage> {
 
 	private final EPackageToJsonSchemaConverter converter;

--- a/org.eclipse.fennec.codec.ods/bnd.bnd
+++ b/org.eclipse.fennec.codec.ods/bnd.bnd
@@ -19,4 +19,3 @@ Bundle-Description: ODS format provider for the Fennec EMF Codec
 -testpath: \
 	org.eclipse.fennec.codec.tests;version=snapshot
 	
--privatepackage: org.eclipse.fennec.codec.ods

--- a/org.eclipse.fennec.codec.ods/src/org/eclipse/fennec/codec/ods/OdsResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.ods/src/org/eclipse/fennec/codec/ods/OdsResourceFactoryComponent.java
@@ -17,11 +17,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for the {@code .ods}
@@ -39,18 +42,33 @@ import org.osgi.service.component.annotations.Reference;
 public class OdsResourceFactoryComponent extends ResourceFactoryImpl {
 
     private final MetadataService metadataService;
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public OdsResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
     }
 
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
+    }
+
     @Override
     public Resource createResource(URI uri) {
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 new OdsFormatProvider());
     }
 }

--- a/org.eclipse.fennec.codec.osgi.tests/src/org/eclipse/fennec/codec/osgi/tests/CustomValueExample.java
+++ b/org.eclipse.fennec.codec.osgi.tests/src/org/eclipse/fennec/codec/osgi/tests/CustomValueExample.java
@@ -34,6 +34,7 @@ import org.eclipse.fennec.codec.constants.CodecOptions;
 import org.eclipse.fennec.codec.resource.CodecResource;
 import org.eclipse.fennec.codec.value.CodecReaderContext;
 import org.eclipse.fennec.codec.value.CodecValueReader;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.codec.value.CodecValueWriter;
 import org.eclipse.fennec.codec.value.CodecWriterContext;
 import org.eclipse.fennec.emf.osgi.helper.EcoreHelper;
@@ -66,9 +67,15 @@ public class CustomValueExample {
     @InjectService
     MetadataService metadataService;
 
+    @InjectService
+    CodecValueRegistry valueRegistry;
+
     private EcoreHelper ecoreHelper;
     private EPackage pkg;
     private ServiceRegistration<EPackage> pkgReg;
+    private ServiceRegistration<?> perTestWriterReg;
+    private ServiceRegistration<?> perTestReaderReg;
+    private BundleContext ctx;
 
     private EClass eventClass;
     private EAttribute eventIdAttr;
@@ -144,6 +151,7 @@ public class CustomValueExample {
 
     @BeforeEach
     public void setUp(@InjectBundleContext BundleContext ctx) throws IOException {
+        this.ctx = ctx;
         ecoreHelper = new EcoreHelper();
         pkg = ecoreHelper.loadEcore(ECORE, CustomValueExample.class);
         EPackage.Registry.INSTANCE.put(pkg.getNsURI(), pkg);
@@ -157,6 +165,14 @@ public class CustomValueExample {
 
     @AfterEach
     public void tearDown() {
+        if (perTestWriterReg != null) {
+            perTestWriterReg.unregister();
+            perTestWriterReg = null;
+        }
+        if (perTestReaderReg != null) {
+            perTestReaderReg.unregister();
+            perTestReaderReg = null;
+        }
         pkgReg.unregister();
         EPackage.Registry.INSTANCE.remove(pkg.getNsURI());
         ecoreHelper.releaseAll();
@@ -239,5 +255,59 @@ public class CustomValueExample {
 
         EObject loaded = loadResource.getContents().get(0);
         assertEquals(millis, loaded.eGet(timestampAttr));
+    }
+
+    @Test
+    @DisplayName("Writer resolved by name from OSGi registry — 'Hello' serialized as 'HELLO'")
+    @SuppressWarnings("unchecked")
+    void writerResolvedByNameFromOsgiRegistry() throws IOException {
+        perTestWriterReg = ctx.registerService(CodecValueWriter.class, new UppercaseWriter(), null);
+
+        EObject event = pkg.getEFactoryInstance().create(eventClass);
+        event.eSet(eventIdAttr, "e3");
+        event.eSet(titleAttr, "Hello");
+
+        Map<String, Object> saveOptions = Map.of(
+                CodecOptions.CODEC_FEATURE_VALUE_WRITERS, Map.of(titleAttr, "uppercase"));
+
+        CodecResource saveResource = new CodecResource(
+                URI.createURI("test://custom-name.json"), metadataService,
+                ConfigurationResolver.defaults(), valueRegistry, null);
+        saveResource.getContents().add(event);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        saveResource.save(out, saveOptions);
+
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("\"HELLO\""),
+                "Should contain uppercase HELLO");
+    }
+
+    @Test
+    @DisplayName("Reader resolved by name from OSGi registry — 'HELLO' deserialized as 'hello'")
+    @SuppressWarnings("unchecked")
+    void readerResolvedByNameFromOsgiRegistry() throws IOException {
+        perTestReaderReg = ctx.registerService(CodecValueReader.class, new LowercaseReader(), null);
+
+        EObject event = pkg.getEFactoryInstance().create(eventClass);
+        event.eSet(eventIdAttr, "e4");
+        event.eSet(titleAttr, "HELLO");
+
+        CodecResource saveResource = new CodecResource(
+                URI.createURI("test://custom-name.json"), metadataService,
+                ConfigurationResolver.defaults(), null, null);
+        saveResource.getContents().add(event);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        saveResource.save(out, Map.of());
+
+        Map<String, Object> loadOptions = new HashMap<>();
+        loadOptions.put(CodecResource.CODEC_ROOT_TYPE, eventClass);
+        loadOptions.put(CodecOptions.CODEC_FEATURE_VALUE_READERS, Map.of(titleAttr, "lowercase"));
+
+        CodecResource loadResource = new CodecResource(
+                URI.createURI("test://custom-name.json"), metadataService,
+                ConfigurationResolver.defaults(), valueRegistry, null);
+        loadResource.load(new ByteArrayInputStream(out.toByteArray()), loadOptions);
+
+        EObject loaded = loadResource.getContents().get(0);
+        assertEquals("hello", loaded.eGet(titleAttr));
     }
 }

--- a/org.eclipse.fennec.codec.playground/bnd.bnd
+++ b/org.eclipse.fennec.codec.playground/bnd.bnd
@@ -1,13 +1,22 @@
 -library: enableEMF
 -buildpath: \
 	org.apache.felix.gogo.runtime,\
-	org.eclipse.fennec.codec,\
-	org.eclipse.fennec.model.metadata,\
-	org.gecko.emf.osgi.example.model.basic,\
-	org.eclipse.fennec.codec.tabular,\
-	org.eclipse.fennec.codec.tabular.model,\
-	org.osgi.service.jakartars,\
-	jakarta.ws.rs-api;version=latest
+	org.eclipse.fennec.codec;version=snapshot,\
+	org.eclipse.fennec.codec.api;version=snapshot,\
+	tools.jackson.core.jackson-core;version=latest,\
+	org.eclipse.fennec.model.metadata;version=snapshot,\
+	org.gecko.emf.osgi.example.model.basic;version=latest,\
+	org.eclipse.fennec.codec.tabular;version=snapshot,\
+	org.eclipse.fennec.codec.tabular.model;version=snapshot,\
+	org.osgi.service.jakartars;version=latest,\
+	jakarta.ws.rs-api;version=latest,\
+	org.eclipse.fennec.codec.csv;version=snapshot,\
+	org.eclipse.fennec.codec.ods;version=snapshot,\
+	org.eclipse.fennec.codec.xlsx;version=snapshot,\
+	org.eclipse.fennec.codec.rlang;version=snapshot,\
+	org.eclipse.fennec.codec.bson;version=snapshot,\
+	org.eclipse.fennec.codec.yaml;version=snapshot,\
+	org.eclipse.fennec.codec.rest;version=snapshot
 	
 -includeresource: OSGI-INF/configurator/=config/
 Require-Capability: \

--- a/org.eclipse.fennec.codec.playground/launch.bndrun
+++ b/org.eclipse.fennec.codec.playground/launch.bndrun
@@ -94,16 +94,9 @@
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)',\
 	bnd.identity;id='org.eclipse.fennec.codec.playground',\
 	bnd.identity;id='org.gecko.emf.osgi.example.model.basic',\
-	bnd.identity;id='org.eclipse.fennec.codec.csv',\
-	bnd.identity;id='org.eclipse.fennec.codec.ods',\
-	bnd.identity;id='org.eclipse.fennec.codec.rlang',\
-	bnd.identity;id='org.eclipse.fennec.codec.xlsx',\
 	bnd.identity;id='org.apache.logging.log4j.api',\
 	bnd.identity;id='org.apache.servicemix.bundles.xmlbeans',\
 	bnd.identity;id='org.apache.commons.commons-collections4',\
 	bnd.identity;id='org.eclipse.fennec.emf.osgi.component',\
-	bnd.identity;id='org.apache.commons.commons-io',\
-	bnd.identity;id='org.eclipse.fennec.codec.rest',\
-	bnd.identity;id='org.eclipse.fennec.codec.bson',\
-	bnd.identity;id='org.eclipse.fennec.codec.yaml'
+	bnd.identity;id='org.apache.commons.commons-io'
 -runee: JavaSE-21

--- a/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/AppendSuffixValueWriter.java
+++ b/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/AppendSuffixValueWriter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2012 - 2026 Data In Motion and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ */
+package org.eclipse.fennec.codec.playground;
+
+import java.io.IOException;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.fennec.codec.value.AttributeValueWriter;
+import org.eclipse.fennec.codec.value.CodecValueWriter;
+import org.eclipse.fennec.codec.value.CodecWriterContext;
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = CodecValueWriter.class)
+public class AppendSuffixValueWriter implements AttributeValueWriter<String> {
+
+	@Override
+	public String getName() {
+		return "appendSuffix";
+	}
+
+	@Override
+	public boolean canHandle(EAttribute attribute) {
+		return EcorePackage.Literals.ESTRING.equals(attribute.getEAttributeType());
+	}
+
+	@Override
+	public void write(String value, EAttribute feature, CodecWriterContext ctx) throws IOException {
+		ctx.getGenerator().writeString(value + "_WRITER");
+	}
+}

--- a/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/ExporterResource.java
+++ b/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/ExporterResource.java
@@ -16,6 +16,14 @@ package org.eclipse.fennec.codec.playground;
 
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.fennec.codec.annotation.RequireCodecJson;
+import org.eclipse.fennec.codec.bson.annotation.RequireCodecBson;
+import org.eclipse.fennec.codec.csv.annotation.RequireCodecCsv;
+import org.eclipse.fennec.codec.ods.annotation.RequireCodecOds;
+import org.eclipse.fennec.codec.rest.annotations.RequireCodecMessageBodyReaderWriter;
+import org.eclipse.fennec.codec.rlang.annotation.RequireCodecRLang;
+import org.eclipse.fennec.codec.xlsx.annotation.RequireCodecXlsx;
+import org.eclipse.fennec.codec.yaml.annotation.RequireCodecYaml;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
@@ -33,6 +41,14 @@ import jakarta.ws.rs.core.Response;
  * @author ilenia
  * @since Jun 3, 2026
  */
+@RequireCodecJson
+@RequireCodecCsv
+@RequireCodecOds
+@RequireCodecXlsx
+@RequireCodecRLang
+@RequireCodecYaml
+@RequireCodecBson
+@RequireCodecMessageBodyReaderWriter
 @JakartarsResource()
 @JakartarsName("ExporterResource")
 @Component(name = "ExporterResource", service = ExporterResource.class, scope = ServiceScope.PROTOTYPE)

--- a/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/TabularExporterCommand.java
+++ b/org.eclipse.fennec.codec.playground/src/org/eclipse/fennec/codec/playground/TabularExporterCommand.java
@@ -24,6 +24,7 @@ import org.apache.felix.service.command.annotations.GogoCommand;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.fennec.codec.constants.CodecOptions;
 import org.eclipse.fennec.codec.tabular.CodecTabularOptions;
 import org.eclipse.fennec.codec.tabular.model.tabular.ReferenceMode;
 import org.gecko.emf.osgi.example.model.basic.Address;
@@ -38,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 @Component(service = TabularExporterCommand.class, scope = ServiceScope.PROTOTYPE)
-@GogoCommand(scope = "exporter", function = "export")
+@GogoCommand(scope = "exporter", function = {"export", "exportWithWriter"})
 public class TabularExporterCommand {
 
 	@Reference
@@ -51,17 +52,31 @@ public class TabularExporterCommand {
 
 	@Descriptor("Export a test object in a resource with the provided URI")
 	public void export(
-			@Descriptor("The type of the export. Could be CSV, ODS, XLSX or R") 
-			String type, 
+			@Descriptor("The type of the export. Could be CSV, ODS, XLSX or R")
+			String type,
 			@Descriptor("The mode for the exporter. Could be IGNORE, FLAT, SQL_TABLES")
 			String mode
 			) throws IOException {
+		doExport(type, mode, new HashMap<>());
+	}
 
+	@Descriptor("Export a test object using the appendSuffix value writer on Person#firstName")
+	public void exportWithWriter(
+			@Descriptor("The type of the export. Could be CSV, ODS, XLSX or R")
+			String type,
+			@Descriptor("The mode for the exporter. Could be IGNORE, FLAT, SQL_TABLES")
+			String mode
+			) throws IOException {
+		Map<String, Object> extra = new HashMap<>();
+		extra.put(CodecOptions.CODEC_FEATURE_VALUE_WRITERS,
+				Map.of(basicPackage.getPerson_FirstName(), "appendSuffix"));
+		doExport(type, mode, extra);
+	}
+
+	private void doExport(String type, String mode, Map<String, Object> options) throws IOException {
 		URI uri = null;
 		ReferenceMode referenceMode = ReferenceMode.valueOf(mode);
-		Map<String, Object> effective = new HashMap<>();
-		effective.putIfAbsent(CodecTabularOptions.OPTION_REFERENCE_MODE,
-				ReferenceMode.valueOf(mode));
+		options.put(CodecTabularOptions.OPTION_REFERENCE_MODE, referenceMode);
 		switch(type) {
 		case "CSV":
 			if(ReferenceMode.SQL_TABLES.equals(referenceMode)) {
@@ -79,27 +94,26 @@ public class TabularExporterCommand {
 		case "R":
 			if(ReferenceMode.SQL_TABLES.equals(referenceMode)) {
 				uri = URI.createURI(TEMP_FOLDER.resolve(UUID.randomUUID().toString().concat(".rdataz")).toString());
-				effective.put("codec.rlang.dataframePerFile", true);
+				options.put("codec.rlang.dataframePerFile", true);
 			} else {
 				uri = URI.createURI(TEMP_FOLDER.resolve(UUID.randomUUID().toString().concat(".RData")).toString());
 			}
+			break;
 		default:
 			System.err.println(String.format("Exporter type %s not supported!", type));
+			return;
 		}
 
 		Resource resource = resourceSet.createResource(uri);
-		Person person1 = createPerson("John", "Doe");
-		Person person2 = createPerson("Mario", "Rossi");
-		resource.getContents().add(person1);
-		resource.getContents().add(person2);
-		
+		resource.getContents().add(createPerson("John", "Doe"));
+		resource.getContents().add(createPerson("Mario", "Rossi"));
+
 		try {
-			resource.save(effective);
+			resource.save(options);
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
 		System.out.println(String.format("Result saved in %s", uri.toString()));
-
 	}
 
 	private Person createPerson(String firstName, String lastName) {

--- a/org.eclipse.fennec.codec.rlang/src/org/eclipse/fennec/codec/rlang/RLangResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.rlang/src/org/eclipse/fennec/codec/rlang/RLangResourceFactoryComponent.java
@@ -19,11 +19,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for R-Language
@@ -51,10 +54,24 @@ public class RLangResourceFactoryComponent extends ResourceFactoryImpl {
     private static final String ZIP_EXTENSION = "rdataz";
 
     private final MetadataService metadataService;
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public RLangResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
+    }
+
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
     }
 
     @Override
@@ -63,10 +80,11 @@ public class RLangResourceFactoryComponent extends ResourceFactoryImpl {
                 ? new RLangFormatProvider(null,
                         Map.of(CodecRLangOptions.OPTION_DATAFRAME_PER_FILE, Boolean.TRUE))
                 : new RLangFormatProvider();
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 provider);
     }
 

--- a/org.eclipse.fennec.codec.tabular/bnd.bnd
+++ b/org.eclipse.fennec.codec.tabular/bnd.bnd
@@ -7,6 +7,8 @@ Bundle-Description: Common bundle for Tabular formats (csv, ods, etc)
 	org.osgi.service.condition;version=latest,\
 	org.eclipse.fennec.codec.api;version=snapshot,\
 	org.eclipse.fennec.codec;version=snapshot,\
+	tools.jackson.core.jackson-core;version=latest,\
+	tools.jackson.core.jackson-databind;version=latest,\
 	org.eclipse.fennec.model.metadata;version=snapshot,\
 	org.eclipse.fennec.codec.metadata;version=snapshot,\
 	org.eclipse.fennec.codec.tabular.model;version=snapshot

--- a/org.eclipse.fennec.codec.tabular/src/org/eclipse/fennec/codec/tabular/TabularDocumentBuilder.java
+++ b/org.eclipse.fennec.codec.tabular/src/org/eclipse/fennec/codec/tabular/TabularDocumentBuilder.java
@@ -12,6 +12,8 @@
  ********************************************************************/
 package org.eclipse.fennec.codec.tabular;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
@@ -41,7 +43,18 @@ import org.eclipse.fennec.codec.config.ConfigProperty;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.config.FeatureConfig;
 import org.eclipse.fennec.codec.config.IdConfig;
+import org.eclipse.fennec.codec.constants.CodecOptions;
 import org.eclipse.fennec.codec.diagnostic.DiagnosticCollector;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
+import org.eclipse.fennec.codec.value.CodecValueWriter;
+import org.eclipse.fennec.codec.value.CodecWriterContext;
+import org.eclipse.fennec.codec.value.EffectiveCodecConfig;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.json.JsonMapper;
 import org.eclipse.fennec.model.metadata.EnumSerializationStrategy;
 import org.eclipse.fennec.codec.tabular.model.tabular.BigDecimalCell;
 import org.eclipse.fennec.codec.tabular.model.tabular.BinaryCell;
@@ -115,10 +128,15 @@ public final class TabularDocumentBuilder {
 
         DiagnosticCollector diagnostics = new DiagnosticCollector();
 
+        CodecValueRegistry registry = opts.get(CodecOptions.INTERNAL_VALUE_REGISTRY) instanceof CodecValueRegistry r ? r : null;
+        @SuppressWarnings("unchecked")
+        Map<EStructuralFeature, String> featureWriters = opts.get(CodecOptions.CODEC_FEATURE_VALUE_WRITERS) instanceof Map<?, ?> m
+                ? (Map<EStructuralFeature, String>) m : null;
+
         switch (mode) {
-            case IGNORE -> buildIgnore(rootList, opts, resolver, diagnostics, doc);
-            case FLAT -> buildFlat(rootList, opts, resolver, diagnostics, doc);
-            case SQL_TABLES -> buildSqlTables(rootList, opts, resolver, diagnostics, doc);
+            case IGNORE -> buildIgnore(rootList, opts, resolver, diagnostics, doc, registry, featureWriters);
+            case FLAT -> buildFlat(rootList, opts, resolver, diagnostics, doc, registry, featureWriters);
+            case SQL_TABLES -> buildSqlTables(rootList, opts, resolver, diagnostics, doc, registry, featureWriters);
         }
         return doc;
     }
@@ -128,7 +146,8 @@ public final class TabularDocumentBuilder {
     // ========================================================================
 
     private static void buildIgnore(List<? extends EObject> roots, Map<String, Object> opts,
-            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc) {
+            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
 
         if (roots.isEmpty()) {
             return;
@@ -188,7 +207,7 @@ public final class TabularDocumentBuilder {
             for (EAttribute attr : attrColumns) {
                 FeatureConfig fc = resolveFeatureConfig(attr, resolver, diagnostics);
                 row.getCells().add(passesValueGate(root, attr, fc)
-                        ? makeAttributeCell(root, attr, fc)
+                        ? makeAttributeCell(root, attr, fc, registry, featureWriters)
                         : TabularFactory.eINSTANCE.createEmptyCell());
             }
             table.getRows().add(row);
@@ -201,7 +220,8 @@ public final class TabularDocumentBuilder {
     // ========================================================================
 
     private static void buildFlat(List<? extends EObject> roots, Map<String, Object> opts,
-            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc) {
+            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
 
         Map<?, ?> columnTypeOverrides = optionAsMap(opts, CodecTabularOptions.OPTION_COLUMN_TYPES);
 
@@ -219,7 +239,7 @@ public final class TabularDocumentBuilder {
             }
             LinkedHashMap<String, Cell> rowMap = new LinkedHashMap<>();
             Deque<EObject> pathStack = new ArrayDeque<>();
-            flatten(root, "", rowMap, columnOrder, columnAttributes, pathStack, resolver, diagnostics);
+            flatten(root, "", rowMap, columnOrder, columnAttributes, pathStack, resolver, diagnostics, registry, featureWriters);
             rowMaps.add(rowMap);
         }
 
@@ -274,7 +294,8 @@ public final class TabularDocumentBuilder {
     private static void flatten(EObject obj, String prefix,
             LinkedHashMap<String, Cell> rowMap, LinkedHashSet<String> columnOrder,
             Map<String, EAttribute> columnAttributes, Deque<EObject> path,
-            ConfigurationResolver resolver, DiagnosticCollector diagnostics) {
+            ConfigurationResolver resolver, DiagnosticCollector diagnostics,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
 
         // Identity-based cycle guard.
         for (EObject ancestor : path) {
@@ -301,7 +322,7 @@ public final class TabularDocumentBuilder {
                         continue;
                     }
                     String column = prefix + resolvedKey;
-                    rowMap.put(column, makeAttributeCell(obj, attr, fc));
+                    rowMap.put(column, makeAttributeCell(obj, attr, fc, registry, featureWriters));
                     columnOrder.add(column);
                     columnAttributes.putIfAbsent(column, attr);
                 } else if (feat instanceof EReference ref) {
@@ -316,14 +337,15 @@ public final class TabularDocumentBuilder {
                                 if (item instanceof EObject child) {
                                     flatten(child, prefix + resolvedKey + "." + idx + ".",
                                             rowMap, columnOrder, columnAttributes, path,
-                                            resolver, diagnostics);
+                                            resolver, diagnostics, registry, featureWriters);
                                 }
                                 idx++;
                             }
                         }
                     } else if (value instanceof EObject child) {
                         flatten(child, prefix + resolvedKey + ".",
-                                rowMap, columnOrder, columnAttributes, path, resolver, diagnostics);
+                                rowMap, columnOrder, columnAttributes, path, resolver, diagnostics,
+                                registry, featureWriters);
                     }
                 }
             }
@@ -357,7 +379,8 @@ public final class TabularDocumentBuilder {
     }
 
     private static void buildSqlTables(List<? extends EObject> roots, Map<String, Object> opts,
-            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc) {
+            ConfigurationResolver resolver, DiagnosticCollector diagnostics, TabularDocument doc,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
 
         MultiValuedRefStrategy strategy = resolveMultiValuedRefStrategy(opts);
         Map<?, ?> columnTypeOverrides = optionAsMap(opts, CodecTabularOptions.OPTION_COLUMN_TYPES);
@@ -369,7 +392,8 @@ public final class TabularDocumentBuilder {
         boolean alphabetical = resolveAlphabetical(opts);
         for (Map.Entry<EClass, List<EObject>> entry : walk.byClass.entrySet()) {
             Table table = buildTableForEClass(entry.getKey(), entry.getValue(), walk,
-                    columnTypeOverrides, fkSuffix, schemas, resolver, diagnostics, alphabetical);
+                    columnTypeOverrides, fkSuffix, schemas, resolver, diagnostics, alphabetical,
+                    registry, featureWriters);
             doc.getTables().add(table);
         }
         for (Map.Entry<JoinTableKey, List<JoinTableEntry>> entry : walk.joinTableEntries.entrySet()) {
@@ -447,7 +471,8 @@ public final class TabularDocumentBuilder {
 
     private static Table buildTableForEClass(EClass eClass, List<EObject> objects, WalkResult walk,
             Map<?, ?> columnTypeOverrides, String fkSuffix, Map<?, ?> schemas,
-            ConfigurationResolver resolver, DiagnosticCollector diagnostics, boolean alphabetical) {
+            ConfigurationResolver resolver, DiagnosticCollector diagnostics, boolean alphabetical,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
 
         Table table = TabularFactory.eINSTANCE.createTable();
         table.setEClass(eClass);
@@ -551,7 +576,7 @@ public final class TabularDocumentBuilder {
                 } else {
                     EAttribute attr = (EAttribute) oc.feature();
                     row.getCells().add(passesValueGate(obj, attr, oc.config())
-                            ? makeAttributeCell(obj, attr, oc.config())
+                            ? makeAttributeCell(obj, attr, oc.config(), registry, featureWriters)
                             : TabularFactory.eINSTANCE.createEmptyCell());
                 }
             }
@@ -635,11 +660,29 @@ public final class TabularDocumentBuilder {
     // Cell construction — typed cells dispatched on the EAttribute's EType.
     // ========================================================================
 
-    private static Cell makeAttributeCell(EObject obj, EAttribute attr, FeatureConfig fc) {
+    @SuppressWarnings("unchecked")
+    private static Cell makeAttributeCell(EObject obj, EAttribute attr, FeatureConfig fc,
+            CodecValueRegistry registry, Map<EStructuralFeature, String> featureWriters) {
         Object value = obj.eGet(attr);
         if (value == null) {
             return TabularFactory.eINSTANCE.createEmptyCell();
         }
+
+        // Apply a named CodecValueWriter when one is configured for this attribute.
+        if (registry != null && featureWriters != null) {
+            String writerName = featureWriters.get(attr);
+            if (writerName != null) {
+                CodecValueWriter<Object, EAttribute> writer =
+                        (CodecValueWriter<Object, EAttribute>) registry.getWriter(writerName).orElse(null);
+                if (writer != null) {
+                    Cell cell = invokeWriterAsCell(writer, value, attr);
+                    if (cell != null) {
+                        return cell;
+                    }
+                }
+            }
+        }
+
         String dateFormat = fc != null ? fc.getDateFormat() : null;
         EnumSerializationStrategy enumStrategy = fc != null ? fc.getEnumSerialization() : null;
 
@@ -660,6 +703,70 @@ public final class TabularDocumentBuilder {
             return cell;
         }
         return makeScalarCell(value, dateFormat, enumStrategy);
+    }
+
+    /**
+     * Invokes a {@link CodecValueWriter} by routing it through a temporary Jackson generator,
+     * then reads the produced JSON token back as a typed {@link Cell}.
+     */
+    private static Cell invokeWriterAsCell(CodecValueWriter<Object, EAttribute> writer,
+            Object value, EAttribute attr) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectMapper mapper = JsonMapper.builder().build();
+            try (JsonGenerator gen = mapper.createGenerator(baos)) {
+                writer.write(value, attr, new MinimalWriterContext(gen));
+            }
+            try (JsonParser parser = mapper.createParser(baos.toByteArray())) {
+                JsonToken token = parser.nextToken();
+                if (token == null) {
+                    return null;
+                }
+                switch (token) {
+                    case VALUE_STRING: {
+                        StringCell cell = TabularFactory.eINSTANCE.createStringCell();
+                        cell.setValue(parser.getString());
+                        return cell;
+                    }
+                    case VALUE_NUMBER_INT: {
+                        LongCell cell = TabularFactory.eINSTANCE.createLongCell();
+                        cell.setValue(parser.getLongValue());
+                        return cell;
+                    }
+                    case VALUE_NUMBER_FLOAT: {
+                        DoubleCell cell = TabularFactory.eINSTANCE.createDoubleCell();
+                        cell.setValue(parser.getDoubleValue());
+                        return cell;
+                    }
+                    case VALUE_TRUE: case VALUE_FALSE: {
+                        BooleanCell cell = TabularFactory.eINSTANCE.createBooleanCell();
+                        cell.setValue(parser.getBooleanValue());
+                        return cell;
+                    }
+                    default:
+                        return null;
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.warning(() -> "TabularDocumentBuilder: value writer failed for attribute '"
+                    + attr.getName() + "': " + e.getMessage());
+            return null;
+        }
+    }
+
+    /** Minimal {@link CodecWriterContext} backed by a capturing {@link JsonGenerator}. */
+    private static final class MinimalWriterContext implements CodecWriterContext {
+        private final JsonGenerator gen;
+        private final DiagnosticCollector diagnostics = new DiagnosticCollector();
+
+        MinimalWriterContext(JsonGenerator gen) {
+            this.gen = gen;
+        }
+
+        @Override public JsonGenerator getGenerator() { return gen; }
+        @Override public SerializationContext getJacksonContext() { return null; }
+        @Override public EffectiveCodecConfig getConfig() { return null; }
+        @Override public DiagnosticCollector getDiagnostics() { return diagnostics; }
     }
 
     private static Cell makeScalarCell(Object value, String dateFormat,

--- a/org.eclipse.fennec.codec.tests/src/org/eclipse/fennec/codec/tests/tck/AbstractCustomValueTCK.java
+++ b/org.eclipse.fennec.codec.tests/src/org/eclipse/fennec/codec/tests/tck/AbstractCustomValueTCK.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.constants.CodecOptions;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.codec.format.CodecFormatProvider;
 import org.eclipse.fennec.codec.resource.CodecResource;
 import org.eclipse.fennec.codec.util.MetadataServiceFactory;
@@ -124,15 +125,81 @@ public abstract class AbstractCustomValueTCK {
         assertEquals(3.14, (Double) loaded.eGet(valueAttr), 0.001);
     }
 
+    @Test
+    @DisplayName("writer resolved by name from registry via save options")
+    void writerResolvedByNameFromRegistry() throws IOException {
+        UppercaseWriter uppercaseWriter = new UppercaseWriter();
+
+        CodecValueRegistry registry = new CodecValueRegistry();
+        registry.register(uppercaseWriter);
+
+        EObject record = testPackage.getEFactoryInstance().create(dataRecordClass);
+        record.eSet(idAttr, "rec-2");
+        record.eSet(labelAttr, "hello");
+        record.eSet(valueAttr, 1.0);
+
+        CodecResource saveResource = createResource(registry);
+        saveResource.getContents().add(record);
+
+        Map<String, Object> saveOptions = new HashMap<>();
+        saveOptions.put(CodecOptions.CODEC_FEATURE_VALUE_WRITERS, Map.of(labelAttr, "uppercaseWriter"));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        saveResource.save(out, saveOptions);
+
+        // Verify the serialized form contains the uppercase value
+        String serialized = out.toString(java.nio.charset.StandardCharsets.UTF_8);
+        assertNotNull(serialized);
+        assertEquals(true, serialized.contains("HELLO"),
+                "Serialized output should contain uppercase HELLO, but got: " + serialized);
+    }
+
+    @Test
+    @DisplayName("reader resolved by name from registry via load options")
+    void readerResolvedByNameFromRegistry() throws IOException {
+        LowercaseReader lowercaseReader = new LowercaseReader();
+
+        CodecValueRegistry registry = new CodecValueRegistry();
+        registry.register(lowercaseReader);
+
+        EObject record = testPackage.getEFactoryInstance().create(dataRecordClass);
+        record.eSet(idAttr, "rec-3");
+        record.eSet(labelAttr, "UPPERCASE");
+        record.eSet(valueAttr, 2.0);
+
+        // Serialize without any custom writer (plain)
+        CodecResource saveResource = createResource(null);
+        saveResource.getContents().add(record);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        saveResource.save(out, Map.of());
+
+        // Deserialize with the lowercase reader resolved by name
+        CodecResource loadResource = createResource(registry);
+        Map<String, Object> loadOptions = new HashMap<>();
+        loadOptions.put(CodecResource.CODEC_ROOT_TYPE, dataRecordClass);
+        loadOptions.put(CodecOptions.CODEC_FEATURE_VALUE_READERS, Map.of(labelAttr, "lowercaseReader"));
+
+        loadResource.load(new ByteArrayInputStream(out.toByteArray()), loadOptions);
+
+        EObject loaded = loadResource.getContents().isEmpty() ? null : loadResource.getContents().get(0);
+        assertNotNull(loaded);
+        assertEquals("uppercase", loaded.eGet(labelAttr),
+                "Label should be lowercase after name-resolved reader");
+    }
+
     // ========================================================================
     // Helpers
     // ========================================================================
 
     private CodecResource createResource() {
+        return createResource(null);
+    }
+
+    private CodecResource createResource(CodecValueRegistry registry) {
         return new CodecResource(
                 URI.createURI("test://customvalue." + getFileExtension()),
                 metadataService, ConfigurationResolver.defaults(),
-                null, null, createFormatProvider());
+                registry, null, createFormatProvider());
     }
 
     /**

--- a/org.eclipse.fennec.codec.xlsx/src/org/eclipse/fennec/codec/xlsx/XlsxResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.xlsx/src/org/eclipse/fennec/codec/xlsx/XlsxResourceFactoryComponent.java
@@ -17,11 +17,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for the
@@ -40,18 +43,33 @@ import org.osgi.service.component.annotations.Reference;
 public class XlsxResourceFactoryComponent extends ResourceFactoryImpl {
 
     private final MetadataService metadataService;
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public XlsxResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
     }
 
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
+    }
+
     @Override
     public Resource createResource(URI uri) {
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 new XlsxFormatProvider());
     }
 }

--- a/org.eclipse.fennec.codec.yaml/src/org/eclipse/fennec/codec/yaml/YamlResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec.yaml/src/org/eclipse/fennec/codec/yaml/YamlResourceFactoryComponent.java
@@ -17,11 +17,14 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
 import org.eclipse.fennec.codec.resource.CodecResource;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * OSGi DS component that registers a {@link Resource.Factory} for the
@@ -43,18 +46,33 @@ public class YamlResourceFactoryComponent extends ResourceFactoryImpl {
 
     private final MetadataService metadataService;
     private final YamlFormatProvider formatProvider = new YamlFormatProvider();
+    private volatile CodecValueRegistry valueRegistry;
 
     @Activate
     public YamlResourceFactoryComponent(@Reference MetadataService metadataService) {
         this.metadataService = metadataService;
     }
 
+    @Reference(
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetValueRegistry"
+    )
+    void setValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = registry;
+    }
+
+    void unsetValueRegistry(CodecValueRegistry registry) {
+        this.valueRegistry = null;
+    }
+
     @Override
     public Resource createResource(URI uri) {
+        CodecValueRegistry reg = valueRegistry;
         return new CodecResource(
                 uri, metadataService,
                 ConfigurationResolver.defaults(),
-                null, null,
+                reg != null ? reg.copy() : null, null,
                 formatProvider);
     }
 }

--- a/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/deser/AttributeDeserializationEntry.java
+++ b/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/deser/AttributeDeserializationEntry.java
@@ -790,7 +790,21 @@ public class AttributeDeserializationEntry implements DeserializationEntry {
             }
         }
 
-        // Priority 2: Use pre-resolved reader from registry
+        // Priority 2: Name-based binding from options (runtime override)
+        if (ctxt != null && entryContext != null) {
+            String readerName = ContextHelper.getFeatureValueReader(ctxt, attribute);
+            if (readerName != null && !readerName.isEmpty()) {
+                CodecValueRegistry registry = entryContext.getValueRegistry();
+                if (registry != null) {
+                    CodecValueReader<?, ?> namedReader = registry.getReader(readerName).orElse(null);
+                    if (namedReader != null) {
+                        return (CodecValueReader<Object, EAttribute>) namedReader;
+                    }
+                }
+            }
+        }
+
+        // Priority 3: Pre-resolved reader from registry (via valueReaderName annotation/config)
         return customReader;
     }
 

--- a/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecResource.java
+++ b/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecResource.java
@@ -450,6 +450,9 @@ public class CodecResource extends ResourceImpl {
     private <T> void doSaveWithFormat(OutputStream outputStream,
             Map<String, Object> effectiveOptions, ConfigurationResolver operationResolver) throws IOException {
         CodecFormatProvider<?, T> provider = (CodecFormatProvider<?, T>) formatProvider;
+        if (valueRegistry != null) {
+            effectiveOptions.put(CodecOptions.INTERNAL_VALUE_REGISTRY, valueRegistry);
+        }
         FormatDelegate<T> delegate = provider.createWriter((T) outputStream, getContents(),
                 effectiveOptions, operationResolver);
 

--- a/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecResourceFactoryComponent.java
+++ b/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecResourceFactoryComponent.java
@@ -20,9 +20,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceFactoryImpl;
 import org.eclipse.fennec.codec.config.ConfigurationResolver;
-import org.eclipse.fennec.codec.value.CodecValueReader;
 import org.eclipse.fennec.codec.value.CodecValueRegistry;
-import org.eclipse.fennec.codec.value.CodecValueWriter;
 import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.model.metadata.api.MetadataService;
 import org.osgi.service.component.annotations.Activate;
@@ -48,7 +46,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 public class CodecResourceFactoryComponent extends ResourceFactoryImpl {
 
 	private final MetadataService metadataService;
-	private final CodecValueRegistry valueRegistry = new CodecValueRegistry();
+	private volatile CodecValueRegistry valueRegistry;
 	private volatile ConfigurationResolver resolver = ConfigurationResolver.defaults();
 
 	@Activate
@@ -57,41 +55,27 @@ public class CodecResourceFactoryComponent extends ResourceFactoryImpl {
 		this.metadataService = metadataService;
 	}
 
-	// --- Whiteboard: Custom Value Writers ---
 	@Reference(
-			cardinality = ReferenceCardinality.MULTIPLE,
+			cardinality = ReferenceCardinality.OPTIONAL,
 			policy = ReferencePolicy.DYNAMIC,
-			unbind = "removeValueWriter"
-			)
-	void addValueWriter(CodecValueWriter<?, ?> writer) {
-		valueRegistry.register(writer);
+			unbind = "unsetValueRegistry"
+	)
+	void setValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = registry;
 	}
 
-	void removeValueWriter(CodecValueWriter<?, ?> writer) {
-		valueRegistry.unregisterWriter(writer.getName());
-	}
-
-	// --- Whiteboard: Custom Value Readers ---
-	@Reference(
-			cardinality = ReferenceCardinality.MULTIPLE,
-			policy = ReferencePolicy.DYNAMIC,
-			unbind = "removeValueReader"
-			)
-	void addValueReader(CodecValueReader<?, ?> reader) {
-		valueRegistry.register(reader);
-	}
-
-	void removeValueReader(CodecValueReader<?, ?> reader) {
-		valueRegistry.unregisterReader(reader.getName());
+	void unsetValueRegistry(CodecValueRegistry registry) {
+		this.valueRegistry = null;
 	}
 
 	@Override
 	public Resource createResource(URI uri) {
+		CodecValueRegistry reg = valueRegistry;
 		return new CodecResource(
 				uri,
 				metadataService,
 				resolver,
-				valueRegistry.copy(),  // snapshot to avoid concurrent modification
+				reg != null ? reg.copy() : null,
 				null,                  // mapperBuilder (default)
 				null,                  // formatProvider (JSON = null)
 				null                   // typeDiscriminatorReader (built internally)

--- a/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecValueRegistryComponent.java
+++ b/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/resource/CodecValueRegistryComponent.java
@@ -1,0 +1,76 @@
+/********************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Data In Motion Consulting - initial implementation
+ ********************************************************************/
+package org.eclipse.fennec.codec.resource;
+
+import org.eclipse.fennec.codec.value.CodecValueReader;
+import org.eclipse.fennec.codec.value.CodecValueRegistry;
+import org.eclipse.fennec.codec.value.CodecValueWriter;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * OSGi DS component that exposes a shared {@link CodecValueRegistry} service.
+ * <p>
+ * Any bundle that registers a {@link CodecValueWriter} or {@link CodecValueReader}
+ * as an OSGi service is automatically picked up and added to this registry. All
+ * resource factory components ({@code CodecResourceFactoryComponent},
+ * {@code BsonResourceFactoryComponent}, etc.) reference this service optionally,
+ * so value handlers registered once are available across all formats.
+ * </p>
+ *
+ * <h3>Usage — registering a custom value writer</h3>
+ * <pre>
+ * &#64;Component(service = CodecValueWriter.class)
+ * public class MyDateWriter implements AttributeValueWriter&lt;Date&gt; {
+ *     &#64;Override public String getName() { return "isoDate"; }
+ *     &#64;Override public void write(Date value, EAttribute f, CodecWriterContext ctx) { ... }
+ * }
+ * </pre>
+ * The writer is automatically registered into this component and available to every
+ * format that uses the shared registry.
+ */
+@Component(
+        name = "CodecValueRegistryComponent",
+        service = CodecValueRegistry.class,
+        immediate = true
+)
+public class CodecValueRegistryComponent extends CodecValueRegistry {
+
+    @Reference(
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeValueWriter"
+    )
+    void addValueWriter(CodecValueWriter<?, ?> writer) {
+        register(writer);
+    }
+
+    void removeValueWriter(CodecValueWriter<?, ?> writer) {
+        unregisterWriter(writer.getName());
+    }
+
+    @Reference(
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeValueReader"
+    )
+    void addValueReader(CodecValueReader<?, ?> reader) {
+        register(reader);
+    }
+
+    void removeValueReader(CodecValueReader<?, ?> reader) {
+        unregisterReader(reader.getName());
+    }
+}

--- a/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/ser/AttributeSerializationEntry.java
+++ b/org.eclipse.fennec.codec/src/org/eclipse/fennec/codec/ser/AttributeSerializationEntry.java
@@ -308,7 +308,21 @@ public class AttributeSerializationEntry implements SerializationEntry {
             }
         }
 
-        // Priority 2: Use pre-resolved writer from registry
+        // Priority 2: Name-based binding from options (runtime override)
+        if (ctxt != null && entryContext != null) {
+            String writerName = ContextHelper.getFeatureValueWriter(ctxt, attribute);
+            if (writerName != null && !writerName.isEmpty()) {
+                CodecValueRegistry registry = entryContext.getValueRegistry();
+                if (registry != null) {
+                    CodecValueWriter<?, ?> namedWriter = registry.getWriter(writerName).orElse(null);
+                    if (namedWriter != null) {
+                        return (CodecValueWriter<Object, EAttribute>) namedWriter;
+                    }
+                }
+            }
+        }
+
+        // Priority 3: Pre-resolved writer from registry (via valueWriterName annotation/config)
         return customWriter;
     }
 }

--- a/org.eclipse.fennec.codec/test/org/eclipse/fennec/codec/resource/CodecResourceCustomValueTest.java
+++ b/org.eclipse.fennec.codec/test/org/eclipse/fennec/codec/resource/CodecResourceCustomValueTest.java
@@ -357,6 +357,69 @@ class CodecResourceCustomValueTest {
     }
 
     @Nested
+    @DisplayName("Name Binding Tests (via options)")
+    class NameBindingTests {
+
+        @Test
+        @DisplayName("Writer name binding via save options resolves from registry")
+        void writerNameBindingViaSaveOptions() throws IOException {
+            CodecValueWriter<String, EAttribute> uppercaseWriter = new CodecValueWriter<>() {
+                @Override
+                public String getName() {
+                    return "uppercase";
+                }
+
+                @Override
+                public void write(String value, EAttribute feature, CodecWriterContext ctx) throws IOException {
+                    ctx.getGenerator().writeString(value.toUpperCase());
+                }
+            };
+
+            valueRegistry.register(uppercaseWriter);
+
+            EObject person = createPerson("alice", 30);
+            ConfigurationResolver resolver = ConfigurationResolver.defaults();
+
+            Map<String, Object> saveOptions = Map.of(
+                    CodecOptions.CODEC_FEATURE_VALUE_WRITERS, Map.of(nameAttribute, "uppercase")
+            );
+
+            String json = serializeWithOptions(person, resolver, valueRegistry, saveOptions);
+            assertTrue(json.contains("\"ALICE\""), "Should contain uppercase ALICE, but got: " + json);
+        }
+
+        @Test
+        @DisplayName("Reader name binding via load options resolves from registry")
+        void readerNameBindingViaLoadOptions() throws IOException {
+            CodecValueReader<String, EAttribute> lowercaseReader = new CodecValueReader<>() {
+                @Override
+                public String getName() {
+                    return "lowercase";
+                }
+
+                @Override
+                public String read(CodecReaderContext ctx, EAttribute feature) throws IOException {
+                    return ctx.getParser().getString().toLowerCase();
+                }
+            };
+
+            valueRegistry.register(lowercaseReader);
+
+            String json = "{\"name\": \"UPPERCASE_NAME\", \"age\": 25}";
+            ConfigurationResolver resolver = ConfigurationResolver.defaults();
+
+            Map<String, Object> loadOptions = Map.of(
+                    CodecResource.CODEC_ROOT_TYPE, personClass,
+                    CodecOptions.CODEC_FEATURE_VALUE_READERS, Map.of(nameAttribute, "lowercase")
+            );
+
+            EObject loaded = deserializeWithOptions(json, resolver, valueRegistry, loadOptions);
+            assertNotNull(loaded);
+            assertEquals("uppercase_name", loaded.eGet(nameAttribute));
+        }
+    }
+
+    @Nested
     @DisplayName("Instance Binding Tests (via options)")
     class InstanceBindingTests {
 


### PR DESCRIPTION
codec value registry as osgi service
codec value reader/writer by name was silently ignored --> now is fixed
tabular formats now support custom value writers as well